### PR TITLE
Add back-off when polling for React's presence and it's not found

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "author": "Kent C. Dodds",
   "version": "1.1",
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "persistent": false
   },
   "content_scripts": [
     {


### PR DESCRIPTION
So that the extension doesn't need a separate Chrome process most of the time.
