### PR TITLE
Update detection to partially work for React v0.15

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,5 +1,7 @@
+var selector = '[data-reactroot], [data-reactid]';
+
 function checkForReact() {
-  var runningReact = !!document.querySelector('[data-reactid]');
+  var runningReact = !!document.querySelector(selector);
   if (runningReact) {
     chrome.runtime.sendMessage({react: true});
   } else {
@@ -20,7 +22,7 @@ chrome.runtime.onMessage.addListener(
       } else {
         outlinesStyleNode = document.createElement('style');
         outlinesStyleNode.textContent =
-          '[data-reactid] {outline: solid 1px rgba(97, 218, 251, 0.4)}';
+          selector + ' {outline: solid 1px rgba(97, 218, 251, 0.4)}';
         document.head.appendChild(outlinesStyleNode);
       }
       outlinesVisible = !outlinesVisible;


### PR DESCRIPTION
Partial fix for Issue 7 - https://github.com/kentcdodds/react-detector/issues/7

Only the root element will be highlighted in React v0.15. Complete solution probably
requires React DevTools: https://github.com/facebook/react/issues/4593

I'm not sure if you're looking for a PR since it's so simple, but I tested this change on FB and it works.
